### PR TITLE
Revised TokenRichlist.js

### DIFF
--- a/TokenRichList.js
+++ b/TokenRichList.js
@@ -44,7 +44,7 @@ const minBalance = 0.00000001;
 async function tokenRichList() {
 
     let client = await ckTools.getClientAsync();
-    let trustLines = await ckTools.getAllTrustLinesAsync(client, issuer, Number.MAX_SAFE_INTEGER, { amount: minBalance, currencyId: currencyId});
+    let trustLines = await ckTools.getAllTrustLinesAsync(client, issuer, maxAccountsToShow, { amount: minBalance, currencyId: currencyId});
 
     trustLines.forEach((trustline) => trustline.balance = ckTools.toPositiveBalance(trustline.balance));
     trustLines = trustLines.sort((a, b) => b.balance - a.balance);


### PR DESCRIPTION
Passed the MaxAccountsToShow const to getAllTrustLinesAsync instead of the default Number.MAX_SAFE_INTEGER (which fails because the script is requesting validated data from a clio server instead of a rippled server with ledger_index set to "current").